### PR TITLE
check null to solve crash

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -752,7 +752,11 @@ public class PDFView extends RelativeLayout {
         state = State.LOADED;
 
         this.pdfFile = pdfFile;
-
+        
+        if (renderingHandlerThread == null) {
+            return;
+        }
+        
         if (!renderingHandlerThread.isAlive()) {
             renderingHandlerThread.start();
         }

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,11 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:3.6.4'
     }
 }
 
-allprojects {
+allprojects{
     repositories {
         google()
         mavenCentral()

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -20,6 +20,13 @@ android {
         targetSdkVersion 28
         versionCode 3
         versionName "3.0.0"
+
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = ["androidManifestFile": "$projectDir/src/main/AndroidManifest.xml".toString()]
+            }
+        }
     }
 
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -14,6 +14,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
+    ndkVersion "21.1.6352462"
 
     defaultConfig {
         minSdkVersion 14


### PR DESCRIPTION
 get crash
Android OS: 9<

Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'boolean android.os.HandlerThread.isAlive()' on a null object reference

com.github.barteksc.pdfviewer.PDFView.loadComplete (PDFView.java:756)
com.github.barteksc.pdfviewer.DecodingAsyncTask.onPostExecute (DecodingAsyncTask.java:80)
com.github.barteksc.pdfviewer.DecodingAsyncTask.onPostExecute (DecodingAsyncTask.java:27)
android.os.AsyncTask.finish (AsyncTask.java:755)
android.os.AsyncTask.access$900 (AsyncTask.java:192)
android.os.AsyncTask$InternalHandler.handleMessage (AsyncTask.java:772)
android.os.Handler.dispatchMessage (Handler.java:107)
android.os.Looper.loop (Looper.java:237)
android.app.ActivityThread.main (ActivityThread.java:8167)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:496)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1100)